### PR TITLE
Perform scalability for larger grids

### DIFF
--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -25,3 +25,20 @@ def disable_repeat_between_setup(benchmark_object):
     benchmark_object.warmup_time = 0.0
 
     return benchmark_object
+
+
+def skip_benchmark(benchmark_object):
+    """
+    Decorator for benchmarks skipping benchmarks.
+    """
+
+    def setup_cache(self):
+        pass
+
+    def setup(*args):
+        raise NotImplementedError
+
+    benchmark_object.setup_cache = setup_cache
+    benchmark_object.setup = setup
+
+    return benchmark_object

--- a/benchmarks/benchmarks/long/esmf_regridder.py
+++ b/benchmarks/benchmarks/long/esmf_regridder.py
@@ -7,7 +7,7 @@ import dask.array as da
 import iris
 from iris.cube import Cube
 
-from benchmarks import disable_repeat_between_setup
+from benchmarks import disable_repeat_between_setup, skip_benchmark
 from esmf_regrid.experimental.unstructured_scheme import (
     GridToMeshESMFRegridder,
     MeshToGridESMFRegridder,
@@ -190,6 +190,9 @@ class PerformScalabilityGridToMesh(PerformScalabilityGridToGrid):
         return tgt
 
 
+# These benchmarks unusually long and are resource intensive so are skipped.
+# They can be run by manually removing the skip.
+@skip_benchmark
 class PerformScalability1kGridToGrid(PerformScalabilityGridToGrid):
     timeout = 600
     grid_size = 1100
@@ -204,6 +207,9 @@ class PerformScalability1kGridToGrid(PerformScalabilityGridToGrid):
         return super().setup_cache()
 
 
+# These benchmarks unusually long and are resource intensive so are skipped.
+# They can be run by manually removing the skip.
+@skip_benchmark
 class PerformScalability2kGridToGrid(PerformScalabilityGridToGrid):
     timeout = 600
     grid_size = 2200


### PR DESCRIPTION
Current scalability benchmarks for performance extend the source cube in the vertical dimension. This makes for a more efficient benchmark since the regridder only has to be made once, which ought to be the most expensive operation. However, since regridding calculations behave differently for the grid dimensions, it is worth capturing the scalability with respect to them.

It should be noted that the grids with this size significantly increase the time and resources taken to run these benchmarks.