### PR TITLE
Use conda-lock `--kind=explicit`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -240,6 +240,7 @@ def update_lockfiles(session: nox.sessions.Session):
         conda_lock_cmd = [
             "conda-lock",
             "lock",
+            "--kind=explicit",
             f"--filename-template={filename_template}",
             f"--file={req_file_local}",
             f"--platform={LOCKFILE_PLATFORM}",


### PR DESCRIPTION
Handles the breaking change from conda-lock `v1.0`. See SciTools/iris#4644.