### PR TITLE
Authorise the lock file pull request using the SciTools App token

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -25,15 +25,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: install nox
         run: |
           source $CONDA/bin/activate base
           conda install -y -c conda-forge nox pyyaml
+
       - name: generate lockfiles
         run: $CONDA/bin/nox --session update_lockfiles
+
+      - name: generate token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - name: create pull request
         uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Updated environment lockfiles
           delete-branch: true
           branch: auto-update-lockfiles


### PR DESCRIPTION
I'm afraid that by far the easiest way to test this is to merge and then run Workflow Dispatch. If we discover problems then I will put in the work to set up a testing instance for myself, but I'd rather do that in the second instance.