### PR TITLE
Use new inbuilt ASV benchmark skipper

### DIFF
--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -28,21 +28,6 @@ def disable_repeat_between_setup(benchmark_object):
     return benchmark_object
 
 
-def skip_benchmark(benchmark_object):
-    """Decorate benchmarks to be skipped.
-
-    Simply doesn't return the object.
-
-    Warnings
-    --------
-    ASV's architecture means decorated classes cannot be sub-classed. Code for
-    inheritance should be in a mixin class that doesn't include any methods
-    which ASV will recognise as benchmarks
-    (e.g. ``def time_something(self):`` ).
-
-    """
-
-
 def on_demand_benchmark(benchmark_object):
     """Decorate benchmark(s) that are disabled unless ON_DEMAND_BENCHARKS env var is set.
 

--- a/benchmarks/benchmarks/esmf_regridder/scalability.py
+++ b/benchmarks/benchmarks/esmf_regridder/scalability.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 
+from asv_runner.benchmarks.mark import skip_benchmark
 import dask.array as da
 import iris
 from iris.cube import Cube
@@ -15,7 +16,7 @@ from esmf_regrid.experimental.unstructured_scheme import (
 )
 from esmf_regrid.schemes import ESMFAreaWeightedRegridder
 
-from .. import on_demand_benchmark, skip_benchmark
+from .. import on_demand_benchmark
 from ..generate_data import _grid_cube, _gridlike_mesh_cube
 
 


### PR DESCRIPTION
Noticed this while setting up the official templated benchmark files.