### PR TITLE
fix unit test schemes dunder imports

### DIFF
--- a/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFAreaWeighted.py
@@ -3,7 +3,7 @@
 import pytest
 
 from esmf_regrid.schemes import ESMFAreaWeighted
-from esmf_regrid.tests.unit.schemes.__init__ import (
+from esmf_regrid.tests.unit.schemes import (
     _test_cube_regrid,
     _test_dtype_handling,
     _test_esmf_args,

--- a/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFBilinear.py
@@ -3,7 +3,7 @@
 import pytest
 
 from esmf_regrid.schemes import ESMFBilinear
-from esmf_regrid.tests.unit.schemes.__init__ import (
+from esmf_regrid.tests.unit.schemes import (
     _test_cube_regrid,
     _test_dtype_handling,
     _test_esmf_args,

--- a/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
+++ b/esmf_regrid/tests/unit/schemes/test_ESMFNearest.py
@@ -5,7 +5,7 @@ from numpy import ma
 import pytest
 
 from esmf_regrid.schemes import ESMFNearest
-from esmf_regrid.tests.unit.schemes.__init__ import (
+from esmf_regrid.tests.unit.schemes import (
     _test_dtype_handling,
     _test_esmf_args,
     _test_mask_from_init,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ exclude = [
     '^benchmarks',
 ]
 strict = false  # Default value, make true when introducing type hinting.
-no_namespace_packages = true
 
 [tool.numpydoc_validation]
 checks = [


### PR DESCRIPTION
Kinda surprised this ever worked.

To be fair, `mypy` was kinda-sorta compliaining about it in a non-obvious way, but I think this explains the inclusion of the `no_namespace_packages` option being enabled ... which is no longer the case.