### PR TITLE
use groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    groups:
+      gha:
+        patterns:
+          - "*"
     labels:
       - "New: Pull Request"
       - "Bot"
+    commit-message:
+      prefix: "chore: "
+      include: "scope"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ ignore = [
     # https://learn.scientific-python.org/development/guides/style/#PC180
     "PC180",  # Uses prettier
     "GH104",  # Unique names for upload artifact
-    # https://learn.scientific-python.org/development/guides/gha-basic/#GH212
-    "GH212",  # Require GHA update grouping
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Reference, see:

- [groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)
- [commit-message](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#commit-message--)