### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [build-system]
 # Defined by PEP 518
 requires = [
-    "setuptools>=61",
+    "setuptools>=77.0.3",
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
@@ -35,7 +34,8 @@ keywords = [
     "esmf",
     "regrid",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "esmf_regrid"
 requires-python = ">=3.11"
 
@@ -57,7 +57,6 @@ xfail_strict = true
 filterwarnings = ["default"]
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.dynamic]

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.11
 
 # Setup dependencies.
-  - setuptools>=40.8.0
+  - setuptools>=77.0.3
 
 # Core dependencies.
   - cartopy>=0.18

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.12
 
 # Setup dependencies.
-  - setuptools>=40.8.0
+  - setuptools>=77.0.3
 
 # Core dependencies.
   - cartopy>=0.18

--- a/requirements/py313.yml
+++ b/requirements/py313.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.13
 
 # Setup dependencies.
-  - setuptools>=40.8.0
+  - setuptools>=77.0.3
 
 # Core dependencies.
   - cartopy>=0.18


### PR DESCRIPTION
This pull-request complies with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```