### PR TITLE
Use esmf-mkfile from data-gen-python in 'run_function_elsewhere'.

### DIFF
--- a/benchmarks/benchmarks/generate_data/__init__.py
+++ b/benchmarks/benchmarks/generate_data/__init__.py
@@ -100,7 +100,7 @@ def run_function_elsewhere(func_to_run, *args, **kwargs):
     )
     python_string = f"{func_string}\n{func_call_string}"
     old_esmf_mk_file = environ.get(ESMFMKFILE, None)
-    environ[ESMFMKFILE] = str(Path(sys.executable).parents[1] / "lib" / "esmf.mk")
+    environ[ESMFMKFILE] = str(Path(DATA_GEN_PYTHON).parents[1] / "lib" / "esmf.mk")
 
     try:
         result = run(


### PR DESCRIPTION
I hope/think this fixes the outstanding benchmarking failures, currently seen on #518 and various others.

The logic of what `run_function_elsewhere` is doing is that it must always have the `ESMFMKFILE` env var pointing at the correct config settings for the install of ESMPy/ESMF within the Python it is going to run.
So, it makes sense to save + restore that, 
but it should be set to the one installed in the called "data-gen" python.
