### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     labels:
       - "New: Pull Request"
       - "Bot"
+    commit-message:
+      prefix: "chore: "
+      include: "scope"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Add missing `commit-message` for the `github-actions` ecosystem.