### PR TITLE
Make regridding serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [PR#655](https://github.com/SciTools/iris-esmf-regrid/pull/655)
+  Enabled the use of Dask distributed and processes schedulers.
+  [@stephenworsley](https://github.com/stephenworsley)
+
 ### Added
 
 - [PR#649](https://github.com/SciTools/iris-esmf-regrid/pull/649)

--- a/src/esmf_regrid/_esmf_sdo.py
+++ b/src/esmf_regrid/_esmf_sdo.py
@@ -72,25 +72,6 @@ class SDO(ABC):
         """Return the mask."""
         return self._mask
 
-    def _array_to_matrix(self, array):
-        """Reshape data to a form that is compatible with weight matrices.
-
-        The data should be presented in the form of a matrix (i.e. 2D) in order
-        to be compatible with the weight matrix.
-        Weight matrices deriving from ESMF use fortran ordering when flattening
-        grids to determine cell indices so we use the same order for reshaping.
-        We then take the transpose so that matrix multiplication happens over
-        the appropriate axes.
-        """
-        return array.T.reshape((self.size, -1))
-
-    def _matrix_to_array(self, array, extra_dims):
-        """Reshape data to restore original dimensions.
-
-        This is the inverse operation of `_array_to_matrix`.
-        """
-        return array.reshape((extra_dims + self._shape)[::-1]).T
-
 
 class GridInfo(SDO):
     """Class for handling structured grids.

--- a/src/esmf_regrid/esmf_regridder.py
+++ b/src/esmf_regrid/esmf_regridder.py
@@ -163,6 +163,10 @@ class Regridder:
             self.esmf_version = ESMF_NO_VERSION
             self.weight_matrix = precomputed_weights
 
+        self.minimal_regridder = MinimalRegridder(
+            self.src.shape, self.tgt.shape, method, self.weight_matrix
+        )
+
     def _out_dtype(self, in_dtype):
         """Return the expected output dtype for a given input dtype."""
         if self.method == Constants.Method.NEAREST:
@@ -257,3 +261,127 @@ class Regridder:
             tgt_weights, tgt_data, extra, norm_type=norm_type, mdtol=mdtol
         )
         return tgt_array
+
+
+class MinimalRegridder:
+    def __init__(self, src_shape, tgt_shape, method, weights):
+        self.src_shape = src_shape
+        self.src_size = np.prod(src_shape)
+        self.src_dims = len(src_shape)
+        self.tgt_shape = tgt_shape
+        self.method = method
+        self.weight_matrix = weights
+
+    def _array_to_matrix(self, array):
+        """Reshape data to a form that is compatible with weight matrices.
+
+        The data should be presented in the form of a matrix (i.e. 2D) in order
+        to be compatible with the weight matrix.
+        Weight matrices deriving from ESMF use fortran ordering when flattening
+        grids to determine cell indices so we use the same order for reshaping.
+        We then take the transpose so that matrix multiplication happens over
+        the appropriate axes.
+        """
+        return array.T.reshape((self.src_size, -1))
+
+    def _matrix_to_array(self, array, extra_dims):
+        """Reshape data to restore original dimensions.
+
+        This is the inverse operation of `_array_to_matrix`.
+        """
+        return array.reshape((extra_dims + self.tgt_shape)[::-1]).T
+
+    def _gen_weights_and_data(self, src_array):
+        extra_shape = src_array.shape[: -self.src_dims]
+
+        if self.method == Constants.Method.NEAREST:
+            weight_matrix = self.weight_matrix.astype(src_array.dtype)
+        else:
+            weight_matrix = self.weight_matrix
+
+        flat_src = self._array_to_matrix(ma.filled(src_array, 0.0))
+        flat_tgt = weight_matrix @ flat_src
+
+        src_inverted_mask = self._array_to_matrix(~ma.getmaskarray(src_array))
+        weight_sums = weight_matrix @ src_inverted_mask
+        return weight_sums, flat_tgt, extra_shape
+
+    def _regrid_from_weights_and_data(
+        self,
+        tgt_weights,
+        tgt_data,
+        extra,
+        norm_type=Constants.NormType.FRACAREA,
+        mdtol=1,
+    ):
+        # Set the minimum mdtol to be slightly higher than 0 to account for rounding
+        # errors.
+        mdtol = max(mdtol, 1e-8)
+        tgt_mask = tgt_weights > 1 - mdtol
+        normalisations = np.ones_like(tgt_data)
+        if self.method != Constants.Method.NEAREST:
+            masked_weight_sums = tgt_weights * tgt_mask
+            if norm_type == Constants.NormType.FRACAREA:
+                normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
+            elif norm_type == Constants.NormType.DSTAREA:
+                pass
+        normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
+
+        tgt_array = tgt_data * normalisations
+        tgt_array = self._matrix_to_array(tgt_array, extra)
+        return tgt_array
+
+    def regrid(self, src_array, norm_type=Constants.NormType.FRACAREA, mdtol=1):
+        """Perform regridding on an array of data.
+
+        Parameters
+        ----------
+        src_array : :obj:`~numpy.typing.ArrayLike`
+            Array whose shape is compatible with ``self.src``.
+        norm_type : :class:`Constants.NormType`
+            Either ``Constants.NormType.FRACAREA`` or ``Constants.NormType.DSTAREA``.
+            Determines the type of normalisation applied to the weights.
+        mdtol : float, default=1
+            A number between 0 and 1 describing the missing data tolerance.
+            Depending on the value of ``mdtol``, if a cell in the target grid is not
+            sufficiently covered by unmasked cells of the source grid, then it will
+            be masked. ``mdtol=1`` means that only target cells which are not
+            covered at all will be masked, ``mdtol=0`` means that all target
+            cells that are not entirely covered will be masked, and ``mdtol=0.5``
+            means that all target cells that are less than half covered will
+            be masked.
+
+        Returns
+        -------
+        :obj:`~numpy.typing.ArrayLike`
+            An array whose shape is compatible with ``self.tgt``.
+
+        """
+        # Sets default value, as this can't be done with class attributes within method call
+        norm_type = check_norm(norm_type)
+
+        array_shape = src_array.shape
+        main_shape = array_shape[-self.src_dims :]
+        if main_shape != self.src_shape:
+            e_msg = (
+                f"Expected an array whose shape ends in {self.src_shape}, "
+                f"got an array with shape ending in {main_shape}."
+            )
+            raise ValueError(e_msg)
+        tgt_weights, tgt_data, extra = self._gen_weights_and_data(src_array)
+        tgt_array = self._regrid_from_weights_and_data(
+            tgt_weights, tgt_data, extra, norm_type=norm_type, mdtol=mdtol
+        )
+        return tgt_array
+
+    def _out_dtype(self, in_dtype):
+        """Return the expected output dtype for a given input dtype."""
+        if self.method == Constants.Method.NEAREST:
+            out_dtype = in_dtype
+        else:
+            weight_matrix = self.weight_matrix
+            weight_dtype = weight_matrix.dtype
+            out_dtype = (
+                np.ones(1, dtype=in_dtype) * np.ones(1, dtype=weight_dtype)
+            ).dtype
+        return out_dtype

--- a/src/esmf_regrid/esmf_regridder.py
+++ b/src/esmf_regrid/esmf_regridder.py
@@ -167,58 +167,6 @@ class Regridder:
             self.src.shape, self.tgt.shape, method, self.weight_matrix
         )
 
-    def _out_dtype(self, in_dtype):
-        """Return the expected output dtype for a given input dtype."""
-        if self.method == Constants.Method.NEAREST:
-            out_dtype = in_dtype
-        else:
-            weight_matrix = self.weight_matrix
-            weight_dtype = weight_matrix.dtype
-            out_dtype = (
-                np.ones(1, dtype=in_dtype) * np.ones(1, dtype=weight_dtype)
-            ).dtype
-        return out_dtype
-
-    def _gen_weights_and_data(self, src_array):
-        extra_shape = src_array.shape[: -self.src.dims]
-
-        if self.method == Constants.Method.NEAREST:
-            weight_matrix = self.weight_matrix.astype(src_array.dtype)
-        else:
-            weight_matrix = self.weight_matrix
-
-        flat_src = self.src._array_to_matrix(ma.filled(src_array, 0.0))
-        flat_tgt = weight_matrix @ flat_src
-
-        src_inverted_mask = self.src._array_to_matrix(~ma.getmaskarray(src_array))
-        weight_sums = weight_matrix @ src_inverted_mask
-        return weight_sums, flat_tgt, extra_shape
-
-    def _regrid_from_weights_and_data(
-        self,
-        tgt_weights,
-        tgt_data,
-        extra,
-        norm_type=Constants.NormType.FRACAREA,
-        mdtol=1,
-    ):
-        # Set the minimum mdtol to be slightly higher than 0 to account for rounding
-        # errors.
-        mdtol = max(mdtol, 1e-8)
-        tgt_mask = tgt_weights > 1 - mdtol
-        normalisations = np.ones_like(tgt_data)
-        if self.method != Constants.Method.NEAREST:
-            masked_weight_sums = tgt_weights * tgt_mask
-            if norm_type == Constants.NormType.FRACAREA:
-                normalisations[tgt_mask] /= masked_weight_sums[tgt_mask]
-            elif norm_type == Constants.NormType.DSTAREA:
-                pass
-        normalisations = ma.array(normalisations, mask=np.logical_not(tgt_mask))
-
-        tgt_array = tgt_data * normalisations
-        tgt_array = self.tgt._matrix_to_array(tgt_array, extra)
-        return tgt_array
-
     def regrid(self, src_array, norm_type=Constants.NormType.FRACAREA, mdtol=1):
         """Perform regridding on an array of data.
 
@@ -245,26 +193,29 @@ class Regridder:
             An array whose shape is compatible with ``self.tgt``.
 
         """
-        # Sets default value, as this can't be done with class attributes within method call
-        norm_type = check_norm(norm_type)
-
-        array_shape = src_array.shape
-        main_shape = array_shape[-self.src.dims :]
-        if main_shape != self.src.shape:
-            e_msg = (
-                f"Expected an array whose shape ends in {self.src.shape}, "
-                f"got an array with shape ending in {main_shape}."
-            )
-            raise ValueError(e_msg)
-        tgt_weights, tgt_data, extra = self._gen_weights_and_data(src_array)
-        tgt_array = self._regrid_from_weights_and_data(
-            tgt_weights, tgt_data, extra, norm_type=norm_type, mdtol=mdtol
+        return self.minimal_regridder.regrid(
+            src_array, norm_type=norm_type, mdtol=mdtol
         )
-        return tgt_array
 
 
 class MinimalRegridder:
     def __init__(self, src_shape, tgt_shape, method, weights):
+        """Create a minimal version of the regridder.
+
+        This regridder object contains only the information required to perform
+        regridding on numpy arrays.
+
+        Parameters
+        ----------
+        src_shape : tuple of int
+            Shape of the source array.
+        tgt_shape : tuple of int
+            Shape of the target array.
+        method : :class:`Constants.Method`
+            The method to be used to calculate weights.
+        weights : :class:`scipy.sparse.spmatrix`
+            The weights matrix to apply.
+        """
         self.src_shape = src_shape
         self.src_size = np.prod(src_shape)
         self.src_dims = len(src_shape)
@@ -331,6 +282,18 @@ class MinimalRegridder:
         tgt_array = self._matrix_to_array(tgt_array, extra)
         return tgt_array
 
+    def _out_dtype(self, in_dtype):
+        """Return the expected output dtype for a given input dtype."""
+        if self.method == Constants.Method.NEAREST:
+            out_dtype = in_dtype
+        else:
+            weight_matrix = self.weight_matrix
+            weight_dtype = weight_matrix.dtype
+            out_dtype = (
+                np.ones(1, dtype=in_dtype) * np.ones(1, dtype=weight_dtype)
+            ).dtype
+        return out_dtype
+
     def regrid(self, src_array, norm_type=Constants.NormType.FRACAREA, mdtol=1):
         """Perform regridding on an array of data.
 
@@ -373,15 +336,3 @@ class MinimalRegridder:
             tgt_weights, tgt_data, extra, norm_type=norm_type, mdtol=mdtol
         )
         return tgt_array
-
-    def _out_dtype(self, in_dtype):
-        """Return the expected output dtype for a given input dtype."""
-        if self.method == Constants.Method.NEAREST:
-            out_dtype = in_dtype
-        else:
-            weight_matrix = self.weight_matrix
-            weight_dtype = weight_matrix.dtype
-            out_dtype = (
-                np.ones(1, dtype=in_dtype) * np.ones(1, dtype=weight_dtype)
-            ).dtype
-        return out_dtype

--- a/src/esmf_regrid/experimental/_partial.py
+++ b/src/esmf_regrid/experimental/_partial.py
@@ -71,7 +71,7 @@ class PartialRegridder(_ESMFRegridder):
         num_dims = len(dims)
         standard_in_dims = [-1, -2][:num_dims]
         data = np.moveaxis(src.data, dims, standard_in_dims)
-        result = self.regridder._gen_weights_and_data(data)
+        result = self.regridder.minimal_regridder._gen_weights_and_data(data)
         return result
 
     def finish_regridding(self, src_cube, weights, data, extra):
@@ -93,7 +93,9 @@ class PartialRegridder(_ESMFRegridder):
         """
         src_dims = self._get_cube_dims(src_cube)
 
-        result_data = self.regridder._regrid_from_weights_and_data(weights, data, extra)
+        result_data = self.regridder.minimal_regridder._regrid_from_weights_and_data(
+            weights, data, extra
+        )
 
         num_out_dims = self.regridder.tgt.dims
         num_dims = len(src_dims)

--- a/src/esmf_regrid/schemes.py
+++ b/src/esmf_regrid/schemes.py
@@ -670,7 +670,7 @@ def _regrid_rectilinear_to_rectilinear__perform(src_cube, regrid_info, mdtol):
     """
     grid_x_dim, grid_y_dim = regrid_info.dims
     grid_x, grid_y = regrid_info.target
-    regridder = regrid_info.regridder
+    regridder = regrid_info.regridder.minimal_regridder
 
     out_dtype = regridder._out_dtype(src_cube.dtype)
 
@@ -757,7 +757,7 @@ def _regrid_unstructured_to_rectilinear__perform(src_cube, regrid_info, mdtol):
     """
     (mesh_dim,) = regrid_info.dims
     grid_x, grid_y = regrid_info.target
-    regridder = regrid_info.regridder
+    regridder = regrid_info.regridder.minimal_regridder
 
     out_dtype = regridder._out_dtype(src_cube.dtype)
 
@@ -852,7 +852,7 @@ def _regrid_rectilinear_to_unstructured__perform(src_cube, regrid_info, mdtol):
     """
     grid_x_dim, grid_y_dim = regrid_info.dims
     mesh, location = regrid_info.target
-    regridder = regrid_info.regridder
+    regridder = regrid_info.regridder.minimal_regridder
 
     if location == "face":
         face_node = mesh.face_node_connectivity
@@ -952,7 +952,7 @@ def _regrid_unstructured_to_unstructured__perform(src_cube, regrid_info, mdtol):
     """
     (mesh_dim,) = regrid_info.dims
     mesh, location = regrid_info.target
-    regridder = regrid_info.regridder
+    regridder = regrid_info.regridder.minimal_regridder
 
     out_dtype = regridder._out_dtype(src_cube.dtype)
 

--- a/src/esmf_regrid/tests/integration/schemes/__init__.py
+++ b/src/esmf_regrid/tests/integration/schemes/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for :mod:`esmf_regrid.schemes`."""

--- a/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
+++ b/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
@@ -1,9 +1,42 @@
+"""Integration test for regridding with different schedulers."""
+
 import contextlib
+
 import dask
+import dask.array as da
 import distributed
+from iris.cube import Cube
+import numpy as np
+from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
+    _grid_cube,
+)
 
 from esmf_regrid.schemes import ESMFAreaWeighted
-from esmf_regrid.tests.unit.schemes import _test_cube_regrid
+
+
+def _test_lazy_regridding():
+    n_lons = 12
+    n_lats = 10
+    h = 4
+    lon_bounds = (-180, 180)
+    lat_bounds = (-90, 90)
+
+    grid = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+    src_data = np.arange(n_lats * n_lons * h, dtype=np.float32).reshape(
+        [n_lats, n_lons, h]
+    )
+    src_data = da.from_array(src_data, chunks=[3, 5, 1])
+    src = Cube(src_data)
+    src.add_dim_coord(grid.coord("latitude"), 0)
+    src.add_dim_coord(grid.coord("longitude"), 1)
+    tgt = _grid_cube(n_lons, n_lats, lon_bounds, lat_bounds, circular=True)
+
+    result = src.regrid(tgt, ESMFAreaWeighted())
+
+    assert result.has_lazy_data()
+    assert result.lazy_data().dtype == np.float64
+    assert result.data.dtype == np.float64
+    assert np.allclose(result.data, src_data)
 
 
 @contextlib.contextmanager
@@ -15,14 +48,14 @@ def distributed_context():
 
 def test_distributed_scheduler():
     with distributed_context():
-        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")
+        _test_lazy_regridding()
 
 
 def test_processes_scheduler():
     with dask.config.set(scheduler="processes"):
-        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")
+        _test_lazy_regridding()
 
 
 def test_threads_scheduler():
     with dask.config.set(scheduler="threads"):
-        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")
+        _test_lazy_regridding()

--- a/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
+++ b/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
@@ -7,11 +7,11 @@ import dask.array as da
 import distributed
 from iris.cube import Cube
 import numpy as np
+
+from esmf_regrid.schemes import ESMFAreaWeighted
 from esmf_regrid.tests.unit.schemes.test__cube_to_GridInfo import (
     _grid_cube,
 )
-
-from esmf_regrid.schemes import ESMFAreaWeighted
 
 
 def _test_lazy_regridding():
@@ -40,22 +40,25 @@ def _test_lazy_regridding():
 
 
 @contextlib.contextmanager
-def distributed_context():
+def _distributed_context():
     _distributed_client = distributed.Client()
     yield
     _distributed_client.close()
 
 
 def test_distributed_scheduler():
-    with distributed_context():
+    """Test regridding works for distributed scheduler."""
+    with _distributed_context():
         _test_lazy_regridding()
 
 
 def test_processes_scheduler():
+    """Test regridding works for processes scheduler."""
     with dask.config.set(scheduler="processes"):
         _test_lazy_regridding()
 
 
 def test_threads_scheduler():
+    """Test regridding works for threads scheduler."""
     with dask.config.set(scheduler="threads"):
         _test_lazy_regridding()

--- a/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
+++ b/src/esmf_regrid/tests/integration/schemes/test_dask_schedulers.py
@@ -1,0 +1,28 @@
+import contextlib
+import dask
+import distributed
+
+from esmf_regrid.schemes import ESMFAreaWeighted
+from esmf_regrid.tests.unit.schemes import _test_cube_regrid
+
+
+@contextlib.contextmanager
+def distributed_context():
+    _distributed_client = distributed.Client()
+    yield
+    _distributed_client.close()
+
+
+def test_distributed_scheduler():
+    with distributed_context():
+        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")
+
+
+def test_processes_scheduler():
+    with dask.config.set(scheduler="processes"):
+        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")
+
+
+def test_threads_scheduler():
+    with dask.config.set(scheduler="threads"):
+        _test_cube_regrid(ESMFAreaWeighted, "grid", "grid")


### PR DESCRIPTION
The lazy regridding operation requires dask to keep hold of a `Regridder` object. This in turn keeps hold of a cartopy `crs` object. This object can cause errors when the dask scheduler is not "threads". This is fixed by creating a minimal version of the regridder object which does not hold on to these objects.