### PR TITLE
Deprecate unstructured_scheme and regrid_rectilinear_to_rectilinear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Added a utility for finding areas of cells on a cube.
   [@stephenworsley](https://github.com/stephenworsley)
 
+### Deprecated
+
+- [PR#666](https://github.com/SciTools/iris-esmf-regrid/pull/666)
+  Deprecated the classes `GridToMeshESMFRegridder` and `MeshToGridESMFRegridder`
+  and the functions `regrid_unstructured_to_rectilinear`,
+  `regrid_rectilinear_to_unstructured` and `regrid_rectilinear_to_rectilinear`.
+  [@stephenworsley](https://github.com/stephenworsley)
+
 ## [0.14.0] - 2026-02-11
 
 ### Added

--- a/docs/src/userguide/scheme_comparison.rst
+++ b/docs/src/userguide/scheme_comparison.rst
@@ -54,6 +54,8 @@ This regridder can then be called by::
 which can be reused on any cube defined on the same horizontal
 coordinates as ``source_cube``.
 
+.. caution:: The following classes are deprecated and will be removed in version 1.0.0.
+
 There are also the experimental regridders
 :class:`~esmf_regrid.experimental.unstructured_scheme.MeshToGridESMFRegridder` and
 :class:`~esmf_regrid.experimental.unstructured_scheme.GridToMeshESMFRegridder`.
@@ -71,6 +73,8 @@ consistency with regridders saved from older versions.
 
 Overview: Miscellaneous Functions
 ---------------------------------
+
+.. caution:: These functions are all deprecated and will be removed in version 1.0.0.
 
 The functions :func:`~esmf_regrid.schemes.regrid_rectilinear_to_rectilinear`,
 :func:`~esmf_regrid.experimental.unstructured_scheme.regrid_unstructured_to_rectilinear` and

--- a/src/esmf_regrid/_deprecation.py
+++ b/src/esmf_regrid/_deprecation.py
@@ -4,5 +4,5 @@ import warnings
 
 
 def warn_deprecated(msg, stacklevel=2):
-    """Issues a deprecation warning."""
+    """Issue a deprecation warning."""
     warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)

--- a/src/esmf_regrid/_deprecations.py
+++ b/src/esmf_regrid/_deprecations.py
@@ -1,0 +1,8 @@
+"""Utilities for producing runtime deprecation messages."""
+
+import warnings
+
+
+def warn_deprecated(msg, stacklevel=2):
+    """Issues a deprecation warning."""
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)

--- a/src/esmf_regrid/experimental/unstructured_scheme.py
+++ b/src/esmf_regrid/experimental/unstructured_scheme.py
@@ -9,7 +9,7 @@ except ImportError as exc:
     except ImportError:
         raise exc from None
 from esmf_regrid import Constants, check_method
-from esmf_regrid._deprecations import warn_deprecated
+from esmf_regrid._deprecation import warn_deprecated
 from esmf_regrid.schemes import (
     _ESMFRegridder,
     _get_mask,
@@ -20,7 +20,6 @@ from esmf_regrid.schemes import (
     _regrid_unstructured_to_unstructured__perform,
     _regrid_unstructured_to_unstructured__prepare,
 )
-
 
 warn_deprecated(
     "esmf_regrid.experimental.unstructured_scheme has been deprecated "

--- a/src/esmf_regrid/experimental/unstructured_scheme.py
+++ b/src/esmf_regrid/experimental/unstructured_scheme.py
@@ -9,6 +9,7 @@ except ImportError as exc:
     except ImportError:
         raise exc from None
 from esmf_regrid import Constants, check_method
+from esmf_regrid._deprecations import warn_deprecated
 from esmf_regrid.schemes import (
     _ESMFRegridder,
     _get_mask,
@@ -18,6 +19,13 @@ from esmf_regrid.schemes import (
     _regrid_unstructured_to_rectilinear__prepare,
     _regrid_unstructured_to_unstructured__perform,
     _regrid_unstructured_to_unstructured__prepare,
+)
+
+
+warn_deprecated(
+    "esmf_regrid.experimental.unstructured_scheme has been deprecated "
+    "and will be removed in 1.0.0. All functionality should be present "
+    "in esmf_regrid.schemes."
 )
 
 

--- a/src/esmf_regrid/schemes.py
+++ b/src/esmf_regrid/schemes.py
@@ -20,6 +20,7 @@ except ImportError as exc:
         raise exc from None
 
 from esmf_regrid import Constants, check_method, esmpy
+from esmf_regrid._deprecations import warn_deprecated
 from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 
@@ -1032,6 +1033,12 @@ def regrid_rectilinear_to_rectilinear(
         A new :class:`~iris.cube.Cube` instance.
 
     """
+    warn_deprecated(
+        "regrid_rectilinear_to_rectilinear has been deprecated and will be removed "
+        "in 1.0.0. The recommended pattern for regridding is now "
+        "`src.regrid(tgt, Scheme())`."
+    )
+
     regrid_info = _regrid_rectilinear_to_rectilinear__prepare(
         src_cube,
         grid_cube,

--- a/src/esmf_regrid/schemes.py
+++ b/src/esmf_regrid/schemes.py
@@ -20,7 +20,7 @@ except ImportError as exc:
         raise exc from None
 
 from esmf_regrid import Constants, check_method, esmpy
-from esmf_regrid._deprecations import warn_deprecated
+from esmf_regrid._deprecation import warn_deprecated
 from esmf_regrid.esmf_regridder import GridInfo, RefinedGridInfo, Regridder
 from esmf_regrid.experimental.unstructured_regrid import MeshInfo
 


### PR DESCRIPTION
Closes #654. Also deprecates additional functions we no longer recommend.