### PR TITLE
Removed importing iris.experimental.ugrid in examples.srt

### DIFF
--- a/docs/src/userguide/examples.rst
+++ b/docs/src/userguide/examples.rst
@@ -7,13 +7,11 @@ Simple Regridding
 To regrid a single Iris_ cube using an area-weighted conservative method::
 
     import iris
-    from iris.experimental.ugrid import PARSE_UGRID_ON_LOAD
     from esmf_regrid.schemes import ESMFAreaWeighted
 
     # An example such a file can be found at:
     # https://github.com/SciTools/iris-test-data/blob/master/test_data/NetCDF/unstructured_grid/data_C4.nc
-    with PARSE_UGRID_ON_LOAD.context():
-        source_mesh_cube = iris.load_cube("mesh_cube.nc")
+    source_mesh_cube = iris.load_cube("mesh_cube.nc")
 
     # An example of such a file can be found at:
     # https://github.com/SciTools/iris-test-data/blob/master/test_data/NetCDF/global/xyt/SMALL_hires_wind_u_for_ipcc4.nc


### PR DESCRIPTION
As of iris 3.10, the experimental ugrid loading has been integrated into the code, so `PARSE_UGRID_ON_LOAD.context()` is no longer needed in the example code