### PR TITLE
Add trusted publishing for pypi and test-pypi

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -120,6 +120,9 @@ jobs:
     needs: [test-artifacts]
     name: "Publish to Test PyPI"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: test-pypi
     # upload to Test PyPI for every commit on main branch
     # and check for the SciTools repo
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'SciTools'
@@ -132,8 +135,6 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
           print_hash: true
@@ -142,6 +143,9 @@ jobs:
     needs: [test-artifacts]
     name: "Publish to PyPI"
     runs-on: ubuntu-latest
+    permissions:
+        id-token: write # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: pypi
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')  && github.repository_owner == 'SciTools'
     steps:
@@ -153,6 +157,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           print_hash: true


### PR DESCRIPTION
Same as [python-stratify#425](https://github.com/SciTools/python-stratify/pull/425)

Requires configuration on PyPi and Test-PyPi